### PR TITLE
fix crash when objectiveProgress is undefined

### DIFF
--- a/collectors/metrics.ts
+++ b/collectors/metrics.ts
@@ -8,6 +8,6 @@ export default function collectDestinyMetrics(profile: DestinyProfileResponse) {
   )) {
     promMetricProgress
       .labels({ metricHash })
-      .set(destinyMetric.objectiveProgress.progress ?? 0);
+      .set(destinyMetric.objectiveProgress?.progress ?? 0);
   }
 }


### PR DESCRIPTION
I don't know why this is happening, maybe I haven't progressed far enough in to the new seasonal content or something?